### PR TITLE
[osers-parser-fix][fix]: handle cases where non-text content are passed to parser

### DIFF
--- a/edscrapers/scrapers/osers/parser.py
+++ b/edscrapers/scrapers/osers/parser.py
@@ -14,7 +14,14 @@ def parse(res):
     """ function parses content to create a dataset model
     or return None if no resource in content"""
 
-    soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
+    # ensure that the response text gotten is a string
+    if not isinstance(getattr(res, 'text', None), str):
+        return None
+
+    try:
+        soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
+    except:
+        return None
 
     # check if the content contains any of the extensions
     if soup_parser.body.find(name='a', href=base_parser.resource_checker,

--- a/edscrapers/scrapers/osers/parsers/osers_parser1.py
+++ b/edscrapers/scrapers/osers/parsers/osers_parser1.py
@@ -11,11 +11,18 @@ from edscrapers.scrapers import base
 from edscrapers.scrapers.base.models import Dataset, Resource
 
 def parse(res):
-
     """ function parses content to create a dataset model
     or return None if no resource in content"""
 
-    soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
+    # ensure that the response text gotten is a string
+    if not isinstance(getattr(res, 'text', None), str):
+        return None
+
+    try:
+        soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
+    except:
+        return None
+        
     # check if the content contains any of the data extensions
     if soup_parser.body.find(name='a', href=base_parser.resource_checker,
                              recursive=True) is None:

--- a/edscrapers/scrapers/osers/parsers/osers_parser2.py
+++ b/edscrapers/scrapers/osers/parsers/osers_parser2.py
@@ -12,8 +12,15 @@ from edscrapers.scrapers.base.models import Dataset, Resource
 def parse(res):
     """ function parses content to create a dataset model """
 
+    # ensure that the response text gotten is a string
+    if not isinstance(getattr(res, 'text', None), str):
+        return None
+
     # create parser object
-    soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
+    try:
+        soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
+    except:
+        return None
 
     dataset_containers = soup_parser.body.find_all(class_='contentText',
                                                    recursive=True)
@@ -78,8 +85,11 @@ def parse(res):
         for resource_link in page_resource_links:
             resource = Resource(source_url=res.url,
                                 url=resource_link['href'])
-            resource['name'] = str(resource_link.find_parent(name='ul').\
+            try:
+                resource['name'] = str(resource_link.find_parent(name='ul').\
                                 find_previous_sibling(name=True))
+            except:
+                resource['name'] = str(resource_link.string).strip()
             resource['name'] +=  " " + str(resource_link.parent.contents[0]).strip()
             resource['name'] = re.sub(r'(</.+>)', '', resource['name'])
             resource['name'] = re.sub(r'(<.+>)', '', resource['name'])


### PR DESCRIPTION
TASK TACKLED
The osers parser is crashing on airflow. Upon further investigation, these bugs were fixed to prevent crashes/errors:
- handled cases were non-text content are handed to parser for parsing;
- also squashed other minor bugs

CONCLUSION
- upon testing, parsing is running COMPLETELY error free

@nightsh please redeploy on airflow to confirm solution. other issues MAY arise from transformers package