### PR TITLE
parser-collections: Implemented Sources and Collections in parsers - tested with P1 (OCR)

### DIFF
--- a/edscrapers/cli.py
+++ b/edscrapers/cli.py
@@ -192,7 +192,7 @@ def dash(detached, port, host, debug, **kwargs):
     ''' Run the dash server for displaying HTML statistics. '''
     setup_logger(kwargs['quiet'], kwargs['verbosity'], 'dash')
     if detached:
-        logger.warn('Dash app detached mode not yet implemented!')
+        logger.warning('Dash app detached mode not yet implemented!')
         logger.info('Falling back to non-detached mode.')
     dash_app.app.run_server(debug=debug, dev_tools_hot_reload=debug, host=host)
 

--- a/edscrapers/scrapers/base/helpers.py
+++ b/edscrapers/scrapers/base/helpers.py
@@ -3,6 +3,7 @@ import re
 import logging
 import datetime
 import hashlib
+import urllib.parse
 import requests
 import bs4
 
@@ -83,9 +84,9 @@ def get_meta_value(soup, meta_name):
 def get_resource_headers(source_url, url):
     headers = dict()
     if urlparse(url).scheme:
-        raw_headers = requests.get(url).headers
+        raw_headers = requests.head(url).headers
     else:
-        raw_headers = requests.get(urljoin(source_url, url)).headers
+        raw_headers = requests.head(urljoin(source_url, url)).headers
 
     headers['content-type'] = raw_headers['Content-Type']
     headers['last-modified'] = raw_headers['Last-Modified']
@@ -135,30 +136,195 @@ def retrieve_crawlers_allowed_domains(except_crawlers=[]) -> list:
             allowed_domains.difference_update(except_allowed_domains)
     return list(allowed_domains) # return allowed_domains
 
-    def extract_dataset_collection_from_url(collection_url, source_url=None):
-        """ function is used to generate/extract a dataset 'Collection' from
-        the provided collection_url.
-        A collection is created based on the Collection model in
-        edscrapers.scrapers.base.models
-        """
-        # make a request for html page contained in the provided url
-        res = requests.get(collection_url, verify=False)
 
-        # ensure that the response text gotten is a string
-        if not isinstance(getattr(res, 'text', None), str):
-            return None
+def extract_dataset_collection_from_url(collection_url,
+                                        namespace, source_url=None):
+    """ function is used to generate/extract a dataset 'Collection' from
+    the provided collection_url.
+    A collection is created based on the Collection model in
+    edscrapers.scrapers.base.models
 
-        try:
-            soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
-        except:
-            return None
-        
-        collection = Collection()
-        collection['collection_url'] = res.url
-        collection['collection_title'] = str(soup_parser.head.\
-                                find(name='title').string).strip()
-        collection['collection_id'] =\
-            f'{hashlib.md5(collection["collection_url"].encode("utf-8")).hexdigest()}-{hashlib.md5(__package__.split(".")[-2].encode("utf-8")).hexdigest()}'
+    PARAMETERS
+    - collection_url: the url from which the Collection should be extracted/generated
 
-        if source_url:
-            pass
+    - namespace: in order to ensure a unique collection_id is created across
+    collections, a namespace MUST be provided, the namespace may be considered as
+    a distinguishing label between Collections with the same title.
+    A Collection's unique id (collection_id) is created using an
+    encoding algorithm which combines the 'collection_url' and 'namespace'.
+
+    - source_url: the url from which the Source (this
+    Collection belongs to) should be extracted/generated.
+    if not specified, it is assumed that the Collection has no source
+
+    Returns a edscrapers.scrapers.base.models.Collection object.
+    If any of the required parameters are not present, None is return
+    """
+
+    # check the required parameters
+    if (not collection_url) or (not namespace):
+        return None
+
+    # cleanup the collection_url i.e. remove all query parameters
+    collection_url = url_query_param_cleanup(collection_url, include_query_param=[])
+
+    # make a request for html page contained in the provided url
+    res = requests.get(collection_url, verify=False)
+
+    # ensure that the response text gotten is a string
+    if not isinstance(getattr(res, 'text', None), str):
+        return None
+
+    try:
+        soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
+    except:
+        return None
+    
+    collection = Collection()
+    collection['collection_url'] = collection_url
+    collection['collection_title'] = str(soup_parser.head.\
+                            find(name='title').string).strip()
+    collection['collection_id'] =\
+        f'{hashlib.md5(collection["collection_url"].encode("utf-8")).hexdigest()}-{hashlib.md5(namespace.encode("utf-8")).hexdigest()}'
+
+    # if source_url was specified and it's an absolute url
+    if source_url and urlparse(source_url).scheme:
+        # generate the Source for this collection
+        collection['source'] = extract_dataset_source_from_url(source_url, namespace)
+    
+    return collection
+
+
+def extract_dataset_source_from_url(source_url, namespace):
+    """ function is used to generate/extract a dataset 'Source' from
+    the provided source_url.
+    A source is created based on the Source model in
+    edscrapers.scrapers.base.models
+
+    PARAMETERS
+    - source_url: the url from which the Source should be extracted/generated
+
+    - namespace: in order to ensure a unique source_id is created across
+    sources, a namespace MUST be provided, the namespace may be considered as
+    a distinguishing label between Sources with the same title.
+    A Source's unique id (source_id) is created using an
+    encoding algorithm which combines the 'source_url' and 'namespace'.
+
+    Returns a edscrapers.scrapers.base.models.Source object.
+    If any of the required parameters are not present, None is return
+    """
+
+    # check the required parameters
+    if (not source_url) or (not namespace):
+        return None
+
+    # cleanup the source_url i.e. remove all query parameters
+    source_url = url_query_param_cleanup(source_url, include_query_param=[])
+    
+    # make a request for html page contained in the provided url
+    res = requests.get(source_url, verify=False)
+
+    # ensure that the response text gotten is a string
+    if not isinstance(getattr(res, 'text', None), str):
+        return None
+
+    try:
+        soup_parser = bs4.BeautifulSoup(res.text, 'html5lib')
+    except:
+        return None
+    
+    source = Source()
+    source['source_url'] = source_url
+    source['source_title'] = str(soup_parser.head.\
+                            find(name='title').string).strip()
+    source['source_id'] =\
+        f'{hashlib.md5(source["source_url"].encode("utf-8")).hexdigest()}-{hashlib.md5(namespace.encode("utf-8")).hexdigest()}'
+
+    return source
+
+
+def url_query_param_cleanup(url: str, include_query_param: list=None,
+                         exclude_query_param: list=None) -> str:
+    """ function helps to remove querystring name/value pairs from the provided url.
+    Returning the 'cleaned up' version of the url (without the specified query parameters).
+    See PARAMETERS for details
+
+    PARAMETERS:
+    - url: represents a valid url which can be parsed by urllib.parse.split()
+    
+    - include_query_param: a list containing the name(s) of query parameters to 
+    be removed from url. if list is None (which is the default), no parameters are
+    stripped. 
+    If list is empty, ALL parameters are stripped
+
+    - exclude_query_param: a list containing the name(s) of query parameters NOT to be 
+    removed from url. That is, ALL available query parameters will
+    be removed from url EXCEPT those provided in this list.
+    if list is None (which is the default), ALL parameters are excluded from stripping.
+    if list is empty, all parameters are excluded from being stripped provided
+    'include_query_param' is None.
+
+    NOTE: in terms of precedence, 'include_query_param' has a higher order than
+    'exclude_query_param'. That is if both 'include_query_param' and
+    'exclude_query_param' are specified AND 'include_query_param' is NOT None,
+    then 'include_query_param' will be applied and 'exclude_query_param' disregarded.
+
+    Returns: function returns a url that has been
+    stripped of querystring name/value pairs"""
+
+    split_url = urllib.parse.urlsplit(url) # holds the split components of the url
+    stripped_url = url # holds the url string after stripping query parameters
+
+    # if no query parameters are included or excluded,
+    if include_query_param is None and exclude_query_param is None:
+        # return a 'cleaned up' (but equivalent) version of the provided url
+        stripped_url = urllib.parse.urlunsplit(urllib.parse.urlsplit(url))
+        return stripped_url # return stripped url
+
+    # if 'include_query_param' is empty list or includes params to be stripped
+    if include_query_param is not None and len(include_query_param) >= 0:
+        # get the query component of the url
+        query_str = split_url.query
+        if query_str == "": # no query string contained in the provided url
+            # return a 'cleaned up' (but equivalent) version of the provided url
+            stripped_url = urllib.parse.urlunsplit(urllib.parse.urlsplit(url))
+        else: # query string was provided
+            query_str_dict = urllib.parse.parse_qs(query_str)
+            query_str_dict2 = dict(query_str_dict)
+            for key in query_str_dict.keys(): # cycle through the query param names
+                    # if any query param name in 'include_query_param' or 'include_query_param' 
+                if key in include_query_param or len(include_query_param) == 0:
+                    del query_str_dict2[key] # delete the query param
+            # convert the ammended query_param dict to a querystring
+            query_str = urllib.parse.urlencode(query_str_dict2, doseq=True)
+            stripped_url = urllib.parse.urlunsplit(urllib.parse.\
+                                                    SplitResult(split_url.scheme,
+                                                                split_url.netloc,
+                                                                split_url.path,
+                                                                query_str,
+                                                                split_url.fragment))
+        return stripped_url # return stripped url
+    
+    # if 'exclude_query_param' is empty list or includes params to be excluded
+    if exclude_query_param is not None and len(exclude_query_param) >= 0:
+        # get the query component of the url
+        query_str = split_url.query
+        if query_str == "": # no query string contained in the provided url
+            # return a 'cleaned up' (but equivalent) version of the provided url
+            stripped_url = urllib.parse.urlunsplit(urllib.parse.urlsplit(url))
+        else: # query string was provided
+            query_str_dict = urllib.parse.parse_qs(query_str)
+            query_str_dict2 = dict(query_str_dict)
+            for key in query_str_dict.keys(): # cycle through the query param names
+                    # if any query param name not in 'exclude_query_param' and 'exclude_query_param' is not empty
+                if key not in exclude_query_param and len(exclude_query_param) > 0:
+                    del query_str_dict2[key] # delete the query param
+            # convert the ammended query_param dict to a querystring
+            query_str = urllib.parse.urlencode(query_str_dict2, doseq=True)
+            stripped_url = urllib.parse.urlunsplit(urllib.parse.\
+                                                    SplitResult(split_url.scheme,
+                                                                split_url.netloc,
+                                                                split_url.path,
+                                                                query_str,
+                                                                split_url.fragment))
+        return stripped_url # return stripped url

--- a/edscrapers/scrapers/base/models.py
+++ b/edscrapers/scrapers/base/models.py
@@ -5,6 +5,18 @@ import hashlib
 from pathlib import Path
 from scrapy import Item, Field
 
+class Source(Item):
+    source_title = Field()
+    source_id = Field()
+    source_url = Field()
+
+class Collection(Item):
+
+    collection_title = Field()
+    collection_id = Field()
+    collection_url = Field()
+    source = Field()
+
 
 class Dataset(Item):
 
@@ -20,6 +32,7 @@ class Dataset(Item):
 
     tags = Field()
     resources = Field()
+    collection = Field()
 
     def toJSON(self):
         return json.dumps(self, default=lambda o: o.__dict__['_values'],

--- a/edscrapers/scrapers/base/pipelines.py
+++ b/edscrapers/scrapers/base/pipelines.py
@@ -15,8 +15,6 @@ class JsonWriterPipeline(object):
     def open_spider(self, spider):
         Path(f"{os.getenv('ED_OUTPUT_PATH')}/scrapers/{spider.name}").\
                                                   mkdir(parents=True, exist_ok=True)
-        Path(f"{os.getenv('ED_OUTPUT_PATH')}/scrapers/{spider.name}/datasets").\
-                                                  mkdir(parents=True, exist_ok=True)
 
     def close_spider(self, spider):
         pass
@@ -27,7 +25,7 @@ class JsonWriterPipeline(object):
         hashed_url = hashlib.md5(dataset['source_url'].encode('utf-8')).hexdigest()
         hashed_name = hashlib.md5(dataset['name'].encode('utf-8')).hexdigest()
         file_name = f"{slug}-{hashed_url}-{hashed_name}.json"
-        file_path = f"{os.getenv('ED_OUTPUT_PATH')}/scrapers/{spider.name}/datasets/{file_name}"
+        file_path = f"{os.getenv('ED_OUTPUT_PATH')}/scrapers/{spider.name}/{file_name}"
         self._log(dataset)
         logger.debug(f"Dumping to {file_path}")
         with open(file_path, 'w') as output:

--- a/edscrapers/scrapers/base/pipelines.py
+++ b/edscrapers/scrapers/base/pipelines.py
@@ -15,6 +15,8 @@ class JsonWriterPipeline(object):
     def open_spider(self, spider):
         Path(f"{os.getenv('ED_OUTPUT_PATH')}/scrapers/{spider.name}").\
                                                   mkdir(parents=True, exist_ok=True)
+        Path(f"{os.getenv('ED_OUTPUT_PATH')}/scrapers/{spider.name}/datasets").\
+                                                  mkdir(parents=True, exist_ok=True)
 
     def close_spider(self, spider):
         pass
@@ -25,7 +27,7 @@ class JsonWriterPipeline(object):
         hashed_url = hashlib.md5(dataset['source_url'].encode('utf-8')).hexdigest()
         hashed_name = hashlib.md5(dataset['name'].encode('utf-8')).hexdigest()
         file_name = f"{slug}-{hashed_url}-{hashed_name}.json"
-        file_path = f"{os.getenv('ED_OUTPUT_PATH')}/scrapers/{spider.name}/{file_name}"
+        file_path = f"{os.getenv('ED_OUTPUT_PATH')}/scrapers/{spider.name}/datasets/{file_name}"
         self._log(dataset)
         logger.debug(f"Dumping to {file_path}")
         with open(file_path, 'w') as output:

--- a/edscrapers/scrapers/ocr/crawler.py
+++ b/edscrapers/scrapers/ocr/crawler.py
@@ -20,15 +20,15 @@ class Crawler(CrawlSpider):
 
         self.start_urls = [
             # The main menu
-            'https://ocrdata.ed.gov/StateNationalEstimations'
-            # 'https://ocrdata.ed.gov/Home',
-            # 'https://ocrdata.ed.gov/DistrictSchoolSearch',
-            # 'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
-            # 'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
-            # 'https://ocrdata.ed.gov/DownloadDataFile',
-            # 'https://ocrdata.ed.gov/StateNationalEstimations',
-            # 'https://ocrdata.ed.gov/SpecialReports',
-            # 'https://ocrdata.ed.gov/DataAnalysisTools',
+            #'https://ocrdata.ed.gov/StateNationalEstimations'
+            'https://ocrdata.ed.gov/Home',
+            'https://ocrdata.ed.gov/DistrictSchoolSearch',
+            'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
+            'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
+            'https://ocrdata.ed.gov/DownloadDataFile',
+            'https://ocrdata.ed.gov/StateNationalEstimations',
+            'https://ocrdata.ed.gov/SpecialReports',
+            'https://ocrdata.ed.gov/DataAnalysisTools'
         ]
 
         """ self.start_urls = [

--- a/edscrapers/scrapers/ocr/crawler.py
+++ b/edscrapers/scrapers/ocr/crawler.py
@@ -20,15 +20,15 @@ class Crawler(CrawlSpider):
 
         self.start_urls = [
             # The main menu
-            'https://ocrdata.ed.gov/Home',
-            'https://ocrdata.ed.gov/DistrictSchoolSearch',
-            'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
-            # 'https://www2.ed.gov/ocr/docs/crdc-2015-16.html',
-            'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
-            'https://ocrdata.ed.gov/DownloadDataFile',
-            'https://ocrdata.ed.gov/StateNationalEstimations',
-            'https://ocrdata.ed.gov/SpecialReports',
-            'https://ocrdata.ed.gov/DataAnalysisTools',
+            'https://ocrdata.ed.gov/StateNationalEstimations'
+            # 'https://ocrdata.ed.gov/Home',
+            # 'https://ocrdata.ed.gov/DistrictSchoolSearch',
+            # 'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
+            # 'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
+            # 'https://ocrdata.ed.gov/DownloadDataFile',
+            # 'https://ocrdata.ed.gov/StateNationalEstimations',
+            # 'https://ocrdata.ed.gov/SpecialReports',
+            # 'https://ocrdata.ed.gov/DataAnalysisTools',
         ]
 
         """ self.start_urls = [

--- a/edscrapers/scrapers/ocr/parsers/ocr_state_national_estimates_parser1.py
+++ b/edscrapers/scrapers/ocr/parsers/ocr_state_national_estimates_parser1.py
@@ -31,11 +31,7 @@ def parse(res) -> dict:
 
         # create the collection
         collection = Collection()
-        collection['collection_url'] = res.url
-        collection['collection_title'] = str(soup_parser.head.\
-                                find(name='title').string).strip()
-        collection['collection_id'] =\
-            f'{hashlib.md5(collection["collection_url"].encode("utf-8")).hexdigest()}-{hashlib.md5(__package__.split(".")[-2].encode("utf-8")).hexdigest()}'
+        
         # attach the source to the collection
         collection['source'] = source
 

--- a/edscrapers/transformers/collections/transform.py
+++ b/edscrapers/transformers/collections/transform.py
@@ -11,6 +11,7 @@ import os
 import json
 from pathlib import Path
 import re
+from collections import Counter
 
 from edscrapers.cli import logger
 from edscrapers.transformers.base import helpers as h
@@ -53,7 +54,8 @@ def transform(name=None, input_file=None):
         collections_list.append(collection)
 
     # get a list of non-duplicate collections
-    collections_list = get_distinct_collections_from(collections_list)
+    collections_list = get_distinct_collections_from(collections_list,
+                                                     min_occurence_counter=2)
     # get the path were the gotten Collections will be saved to on local disk
     file_output_path = f'{CURRENT_TRANSFORMER_OUTPUT_DIR}/{(name or "all")}.collections.json'
     # write to file the collections gotten from 'name' scraped output
@@ -64,17 +66,37 @@ def transform(name=None, input_file=None):
 
 
 def extract_collection_from(dataset: dict, use_key: str='collection') -> dict:
-    """ function is used to extract a Collection from the provided dataset """
+    """ function is used to extract a Collection from the provided dataset 
+    
+    - use_key: the key within the dataset that houses the collection object
+    """
 
     if not dataset.get(use_key, None): # if there is no collection present
         return None
     
-    return dataset[use_key]
+    if len(dataset[use_key]) == 0: # empty key (no collection content)
+        return None
+    
+    return dataset[use_key] # return extracted Collection
 
 
-def get_distinct_collections_from(collection_list) -> list:
+def get_distinct_collections_from(collection_list,
+                                  min_occurence_counter: int=1) -> list:
     """ function returns a list of distinct/unique (non-duplicate) collections
-    extracted from the provided collections list """
+    extracted from the provided collections list 
+    
+    PARAMETERS
+    - collection_list: a list containing the Collections to extract distinct
+    Collections from
+
+    - min_occurence_counter: the operations used to identify a distinct Collection can 
+    be instructed on how to identify a Collection for consideration. The
+    'min_occurence_counter' instructs the algorithm to
+    ignore/remove a Collection from the list of distinct collections if it does not
+    occur/appear within the provided 'collection_list' at least that number of times.
+    The default value is 1. Setting 'min_occurence_counter to < 1 will disable this
+    check when creating a distinct/unique (non-duplicate) Collection list
+    """
 
     if (not collection_list) or len(collection_list) == 0: # parameter not provided
         return None
@@ -83,10 +105,24 @@ def get_distinct_collections_from(collection_list) -> list:
     mapped_collections = map(lambda collection: collection.get('collection_id', 
                                                         collection['collection_title']),
                                    collection_list)
+    
+    # find out if minimum occurence checks should be performed
+    min_occurence_counter = int(min_occurence_counter)
+    if min_occurence_counter > 0: # perform minimum occcurence check
+        collections_counter = Counter(mapped_collections) # Counter for how many times a Collection occurs
+        count_keys = list(collections_counter.keys()) # create a list from the counter key/collection id
+        for key in count_keys: # loop through each counter key/collection id
+            if collections_counter[key] < min_occurence_counter: # if counter key/collection id < min_occurence counter
+                # remove this key as it represents a Collection that occurs less than requested
+                del collections_counter[key]
+        # end of minimum occurence checks,
+        # so, generate the 'mapped' collection list from the results of this check
+        mapped_collections = collections_counter.elements()
+
     # get distinct (non-duplicate) 'mapped' collection_list
     mapped_collections = set(mapped_collections)
 
-    distinct_collection_list = [] # holds the list of distinct collections
+    distinct_collection_list = [] # holds the list of distinct collection objects
     # iterate through 'mapped_collection'
     for mapped_collection in mapped_collections:
         # iterate through 'collection_list'  parameter

--- a/edscrapers/transformers/collections/transform.py
+++ b/edscrapers/transformers/collections/transform.py
@@ -35,7 +35,7 @@ def transform(name=None, input_file=None):
             with open(input_file, 'r') as fp:
                 file_list = [line.rstrip() for line in fp]
         except:
-            logger.warn(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
+            logger.warning(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
             file_list = h.traverse_output(name)
     
     collections_list = [] # holds the list of collections acquired from 'name' scraper directory

--- a/edscrapers/transformers/collections/transform.py
+++ b/edscrapers/transformers/collections/transform.py
@@ -1,0 +1,56 @@
+""" module transforms the raw dataset files (i.e. the results/output from scraping)
+into a different json data structure referred to as Collections.
+Each scraping output directory will have its own
+collections file upon completion of the transformation. Files are titled
+'{name}_collections.json' """
+
+import os
+import json
+from pathlib import Path
+import re
+
+from edscrapers.cli import logger
+from edscrapers.transformers.base import helpers as h
+
+
+OUTPUT_DIR = os.getenv('ED_OUTPUT_PATH') # get the output directory
+
+# get this transformer's output directory
+CURRENT_TRANSFORMER_OUTPUT_DIR = h.get_output_path('collections')
+
+def transform(name=None, input_file=None):
+
+    if input_file is None:
+        file_list = h.traverse_output(name)
+    else:
+        try:
+            with open(input_file, 'r') as fp:
+                file_list = [line.rstrip() for line in fp]
+        except:
+            logger.warn(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
+            file_list = h.traverse_output(name)
+    
+    # loop through filepath in file list
+    for file_path in file_list:
+        # read the json data in each filepath
+        data = h.read_file(file_path)
+        if not data: # if data is None
+            continue
+        # mark as private datasets that have certain keywords in their data
+        data = _mark_private(data, search_words=['conference', 'awards',
+                                                'user guide', 'applications'])
+
+        # mark of removal datasets that have certain keywords
+        data = _remove_dataset(data, search_words=['photo'])
+
+        # REMOVE UNWANTED STRING FROM THE VALUE OF A DATASET'S KEY
+        # 1. remove 'table [0-9].' from beginning of dataset title
+        data = _strip_unwanted_string(data, r'^table [0-9a-z]+(-?[a-z])?\.', 
+                                      dict_key='title')
+        
+        # set the 'level of data' for the dataset
+        data = _set_dataset_level_of_data(data)
+
+        # write modified dataset back to file
+        h.write_file(file_path, data)
+

--- a/edscrapers/transformers/collections/transform.py
+++ b/edscrapers/transformers/collections/transform.py
@@ -2,7 +2,7 @@
 into a different json data structure referred to as Collections.
 Each scraping output directory will have its own
 collections file upon completion of the transformation. Files are titled
-'{name}_collections.json' """
+'{name}.collections.json' """
 
 import os
 import json
@@ -18,10 +18,14 @@ OUTPUT_DIR = os.getenv('ED_OUTPUT_PATH') # get the output directory
 # get this transformer's output directory
 CURRENT_TRANSFORMER_OUTPUT_DIR = h.get_output_path('collections')
 
-def transform(name=None, input_file=None):
 
-    if input_file is None:
-        file_list = h.traverse_output(name)
+def transform(name=None, input_file=None):
+    """
+    function is responsible for transofrming raw datasets into Collections
+    """
+
+    if input_file is None: # no input file specified
+        file_list = h.traverse_output(name) # run through all the files in 'name' directory
     else:
         try:
             with open(input_file, 'r') as fp:
@@ -30,27 +34,64 @@ def transform(name=None, input_file=None):
             logger.warn(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
             file_list = h.traverse_output(name)
     
+    collections_list = [] # holds the list of collections acquired from 'name' scraper directory
     # loop through filepath in file list
     for file_path in file_list:
         # read the json data in each filepath
         data = h.read_file(file_path)
         if not data: # if data is None
             continue
-        # mark as private datasets that have certain keywords in their data
-        data = _mark_private(data, search_words=['conference', 'awards',
-                                                'user guide', 'applications'])
 
-        # mark of removal datasets that have certain keywords
-        data = _remove_dataset(data, search_words=['photo'])
+        # retrieve collection from dataset
+        collection = extract_collection_from(dataset=data, use_key='collection')
+        if not collection: # collection could not be retrieved
+            continue
+        # add collection to list
+        collections_list.append(collection)
 
-        # REMOVE UNWANTED STRING FROM THE VALUE OF A DATASET'S KEY
-        # 1. remove 'table [0-9].' from beginning of dataset title
-        data = _strip_unwanted_string(data, r'^table [0-9a-z]+(-?[a-z])?\.', 
-                                      dict_key='title')
-        
-        # set the 'level of data' for the dataset
-        data = _set_dataset_level_of_data(data)
+    # get a list of non-duplicate collections
+    collections_list = get_distinct_collections_from(collections_list)
+    # get the path were the gotten Collections will be saved to on local disk
+    file_output_path = f'{CURRENT_TRANSFORMER_OUTPUT_DIR}/{(name or "all")}.collections.json'
+    # write to file the collections gotten from 'name' scraped output
+    h.write_file(file_output_path, collections_list)
+    # write file the collections gotten from 'name' scraped out to S3 bucket
+    h.upload_to_s3_if_configured(file_output_path, 
+                                 f'{(name or "all")}.collections.json')
 
-        # write modified dataset back to file
-        h.write_file(file_path, data)
 
+def extract_collection_from(dataset: dict, use_key: str='collection') -> dict:
+    """ function is used to extract a Collection from the provided dataset """
+
+    if not dataset.get(use_key, None): # if there is no collection present
+        return None
+    
+    return dataset[use_key]
+
+
+def get_distinct_collections_from(collection_list) -> list:
+    """ function returns a list of distinct/unique (non-duplicate) collections
+    extracted from the provided collections list """
+
+    if (not collection_list) or len(collection_list) == 0: # parameter not provided
+        return None
+    
+    # get a 'mapped' collection_list for easy operation
+    mapped_collections = map(lambda collection: collection.get('collection_id', 
+                                                        collection['collection_title']),
+                                   collection_list)
+    # get distinct (non-duplicate) 'mapped' collection_list
+    mapped_collections = set(mapped_collections)
+
+    distinct_collection_list = [] # holds the list of distinct collections
+    # iterate through 'mapped_collection'
+    for mapped_collection in mapped_collections:
+        # iterate through 'collection_list'  parameter
+        for collection in collection_list:
+            # the collection has the same id or title as mapped_collection
+            if collection.get('collection_id', collection['collection_title']) == mapped_collection:
+                # add this collection to the list of distinct collection objects
+                distinct_collection_list.append(collection)
+                break # leave the inner loop
+    
+    return distinct_collection_list # return the distinct collection

--- a/edscrapers/transformers/datajson/models.py
+++ b/edscrapers/transformers/datajson/models.py
@@ -36,6 +36,9 @@ class Catalog():
     conformsTo = str()
     describedBy = str()
     datasets = list() # datasets list
+    sources = list() # Sources list
+    collections = list() # Collection list
+
 
     def __init__(self):
         
@@ -65,6 +68,9 @@ class Catalog():
 
         if len(self.datasets) > 0:
             catalog_dict["dataset"] = self.dump_datasets()
+        
+        if len(self.sources) > 0:
+            catalog_dict['source'] = self.dump_sources() 
 
         return catalog_dict
 
@@ -76,11 +82,76 @@ class Catalog():
             datasets_lst.append(dataset.to_dict())
 
         return datasets_lst
+    
+    def dump_sources(self):
+
+        sources_lst = []
+
+        for source in self.sources:
+            sources_lst.append(source.to_dict())
+
+        return sources_lst
+
+    def dump_collections(self):
+
+        collections_lst = []
+
+        for collection in self.collections:
+            collections_lst.append(collection.to_dict())
+
+        return collections_lst
 
     
     def dump(self):
         return json.dumps(self.to_dict(), sort_keys=False, indent=2)
+
+
+class Source():
     
+    id = str()
+    title = str()
+
+    def to_dict(self):
+        
+        source_dict = {}
+
+        if self.id:
+            source_dict['id'] = self.id
+        
+        if self.title:
+            source_dict['title'] = self.title
+        
+        return source_dict
+
+class Collection():
+
+    id = str()
+    title = str()
+    sources = list()
+
+    def to_dict(self):
+
+        collection_dict = {}
+        
+        if self.id:
+            collection_dict['id'] = self.id
+        
+        if self.title:
+            collection_dict['title'] = self.title
+        
+        if len(self.sources) > 0:
+            collection_dict['source'] = self.dump_sources()
+        
+        return collection_dict
+    
+    def dump_sources(self):
+        
+        sources_list = []
+        for source in self.sources:
+            sources_list.append(source.id)
+        return sources_list
+
+
 class Dataset():
     
     dataset_type = str()

--- a/edscrapers/transformers/datajson/models.py
+++ b/edscrapers/transformers/datajson/models.py
@@ -70,7 +70,10 @@ class Catalog():
             catalog_dict["dataset"] = self.dump_datasets()
         
         if len(self.sources) > 0:
-            catalog_dict['source'] = self.dump_sources() 
+            catalog_dict['source'] = self.dump_sources()
+
+        if len(self.collections) > 0:
+            catalog_dict['collection'] = self.dump_collections() 
 
         return catalog_dict
 
@@ -129,6 +132,9 @@ class Collection():
     title = str()
     sources = list()
 
+    def __init(self):
+        self.sources = list()
+
     def to_dict(self):
 
         collection_dict = {}
@@ -171,6 +177,9 @@ class Dataset():
     temporal = str()
     theme = list()
     distribution = list() # resources list
+    levelOfData = str()
+    source = list() # list of Sources
+    collection = list() # list of Collections
 
     def __init__(self):
         
@@ -182,6 +191,9 @@ class Dataset():
         self.spatial = "United States"
         self.description = "n/a"
         self.modified = datetime.now().strftime("%Y-%m-%d")
+        self.distribution = list()
+        self.source = list()
+        self.collection = list()
 
     def to_dict(self):
 
@@ -237,6 +249,15 @@ class Dataset():
 
         if len(self.distribution) > 0:
             dataset_dict["distribution"] = self.dump_resources()
+        
+        if self.levelOfData:
+            dataset_dict['levelOfData'] = self.levelOfData
+        
+        if len(self.source) > 0:
+            dataset_dict['source'] = self.dump_sources()
+        
+        if len(self.collection) > 0:
+            dataset_dict['collection'] = self.dump_collections()
 
         return dataset_dict
 
@@ -248,6 +269,21 @@ class Dataset():
             resources_lst.append(resource.to_dict())
 
         return resources_lst
+    
+    def dump_sources(self):
+        sources_list = []
+
+        for source in self.source:
+            sources_list.append(source.id)
+        return sources_list
+    
+    def dump_collections(self):
+        collections_list = []
+
+        for collection in self.collection:
+            collections_list.append(collection.id)
+        return collections_list
+            
 
 class Resource():
 

--- a/edscrapers/transformers/rag/transform.py
+++ b/edscrapers/transformers/rag/transform.py
@@ -65,7 +65,7 @@ def transform(name=None, input_file=None, use_raw_datasets=False) -> pd.DataFram
                 try:
                     file_list = [line.rstrip() for line in fp]
                 except Exception:
-                    logger.warn(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
+                    logger.warning(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
                     file_list = h.traverse_output(None)
     
     else: # work with processed/transformed datajson
@@ -80,7 +80,7 @@ def transform(name=None, input_file=None, use_raw_datasets=False) -> pd.DataFram
                 try:
                     file_list = [line.rstrip() for line in fp]
                 except Exception:
-                    logger.warn(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
+                    logger.warning(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
                     file_list.extend(Path(h.get_output_path('datajson')).glob('*.json'))
 
     if use_raw_datasets == True: # work on raw datasets

--- a/edscrapers/transformers/sanitize/transform.py
+++ b/edscrapers/transformers/sanitize/transform.py
@@ -34,7 +34,7 @@ def transform(name=None, input_file=None):
                                                 'user guide', 'applications'])
 
         # mark of removal datasets that have certain keywords
-        data = _remove_dataset(data, search_words=['photo'])
+        data = _remove_dataset(data, search_words=['photo', 'foto', 'photos', 'fotos'])
 
         # REMOVE UNWANTED STRING FROM THE VALUE OF A DATASET'S KEY
         # 1. remove 'table [0-9].' from beginning of dataset title

--- a/edscrapers/transformers/sanitize/transform.py
+++ b/edscrapers/transformers/sanitize/transform.py
@@ -20,7 +20,7 @@ def transform(name=None, input_file=None):
             with open(input_file, 'r') as fp:
                 file_list = [line.rstrip() for line in fp]
         except:
-            logger.warn(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
+            logger.warning(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
             file_list = h.traverse_output(name)
     
     # loop through filepath in file list

--- a/edscrapers/transformers/sources/transform.py
+++ b/edscrapers/transformers/sources/transform.py
@@ -9,6 +9,7 @@ All transformation output is written into 'sources' subdirectory of the
 import os
 import json
 from pathlib import Path
+from collections import Counter
 import re
 
 from edscrapers.cli import logger
@@ -18,12 +19,12 @@ from edscrapers.transformers.base import helpers as h
 OUTPUT_DIR = os.getenv('ED_OUTPUT_PATH') # get the output directory
 
 # get this transformer's output directory
-CURRENT_TRANSFORMER_OUTPUT_DIR = h.get_output_path('collections')
+CURRENT_TRANSFORMER_OUTPUT_DIR = h.get_output_path('sources')
 
 
 def transform(name=None, input_file=None):
     """
-    function is responsible for transofrming raw datasets into Collections
+    function is responsible for transofrming raw datasets into Sources
     """
 
     if input_file is None: # no input file specified
@@ -36,7 +37,7 @@ def transform(name=None, input_file=None):
             logger.warn(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
             file_list = h.traverse_output(name)
     
-    collections_list = [] # holds the list of collections acquired from 'name' scraper directory
+    sources_list = [] # holds the list of sources acquired from 'name' scraper directory
     # loop through filepath in file list
     for file_path in file_list:
         # read the json data in each filepath
@@ -44,56 +45,102 @@ def transform(name=None, input_file=None):
         if not data: # if data is None
             continue
 
-        # retrieve collection from dataset
-        collection = extract_collection_from(dataset=data, use_key='collection')
-        if not collection: # collection could not be retrieved
+        # retrieve source from dataset
+        source = extract_source_from(dataset=data, use_key='collection')
+        if not source: # source could not be retrieved
             continue
-        # add collection to list
-        collections_list.append(collection)
+        # add source to list
+        sources_list.append(source)
 
-    # get a list of non-duplicate collections
-    collections_list = get_distinct_collections_from(collections_list)
-    # get the path were the gotten Collections will be saved to on local disk
-    file_output_path = f'{CURRENT_TRANSFORMER_OUTPUT_DIR}/{(name or "all")}.collections.json'
-    # write to file the collections gotten from 'name' scraped output
-    h.write_file(file_output_path, collections_list)
-    # write file the collections gotten from 'name' scraped out to S3 bucket
+    # get a list of non-duplicate Sources
+    sources_list = get_distinct_sources_from(sources_list, min_occurence_counter=1)
+    # get the path were the gotten Sources will be saved to on local disk
+    file_output_path = f'{CURRENT_TRANSFORMER_OUTPUT_DIR}/{(name or "all")}.sources.json'
+    # write to file the Sources gotten from 'name' scraped output
+    h.write_file(file_output_path, sources_list)
+    # write file the Sources gotten from 'name' scraped out to S3 bucket
     h.upload_to_s3_if_configured(file_output_path, 
-                                 f'{(name or "all")}.collections.json')
+                                 f'{(name or "all")}.sources.json')
 
 
-def extract_collection_from(dataset: dict, use_key: str='collection') -> dict:
-    """ function is used to extract a Collection from the provided dataset """
+def extract_source_from(dataset: dict, use_key: str='collection') -> dict:
+    """
+    function is used to extract a Source from the provided dataset.
+    NOTE:
+    In the current sttructure for the raw dataset, a Source object is housed
+    within a Collection object, it is necessary for this function to retrieve/interact
+    with Collection object prior to retrieving the Source object. This implementation
+    may changed in the future if the raw dataset structure changes
+    
+    - use_key: the key within the dataset that houses the COLLECTION
+    """
 
     if not dataset.get(use_key, None): # if there is no collection present
         return None
     
-    return dataset[use_key]
-
-
-def get_distinct_collections_from(collection_list) -> list:
-    """ function returns a list of distinct/unique (non-duplicate) collections
-    extracted from the provided collections list """
-
-    if (not collection_list) or len(collection_list) == 0: # parameter not provided
+    if len(dataset[use_key]) == 0: # empty key (no collection content)
         return None
     
-    # get a 'mapped' collection_list for easy operation
-    mapped_collections = map(lambda collection: collection.get('collection_id', 
-                                                        collection['collection_title']),
-                                   collection_list)
-    # get distinct (non-duplicate) 'mapped' collection_list
-    mapped_collections = set(mapped_collections)
+    if not dataset[use_key].get('source', None): # no Source specified for this Collection
+        return None
+    
+    if len(dataset[use_key]['source']) == 0: # empty key (no Source content)
+        return None
 
-    distinct_collection_list = [] # holds the list of distinct collections
-    # iterate through 'mapped_collection'
-    for mapped_collection in mapped_collections:
-        # iterate through 'collection_list'  parameter
-        for collection in collection_list:
-            # the collection has the same id or title as mapped_collection
-            if collection.get('collection_id', collection['collection_title']) == mapped_collection:
-                # add this collection to the list of distinct collection objects
-                distinct_collection_list.append(collection)
+    return dataset[use_key]['source'] # return extracted Source
+
+
+def get_distinct_sources_from(source_list,
+                                  min_occurence_counter: int=1) -> list:
+    """ function returns a list of distinct/unique (non-duplicate) Sources
+    extracted from the provided sources list
+    
+    PARAMETERS
+    - sources_list: a list containing the Sources to extract distinct
+    Sources from
+
+    - min_occurence_counter: the operations used to identify a distinct Source can 
+    be instructed on how to identify a Collection for consideration. The
+    'min_occurence_counter' instructs the algorithm to
+    ignore/remove a Source from the list of distinct Sources if it does not
+    occur/appear within the provided 'sources_list' at least that number of times.
+    The default value is 1. Setting 'min_occurence_counter to < 1 will disable this
+    check when creating a distinct/unique (non-duplicate) Source list
+    """
+
+    if (not source_list) or len(source_list) == 0: # parameter not provided
+        return None
+    
+    # get a 'mapped' source_list for easy operation
+    mapped_sources = map(lambda source: source.get('source_id', 
+                                                        source['source_title']),
+                                   source_list)
+    
+    # find out if minimum occurence checks should be performed
+    min_occurence_counter = int(min_occurence_counter)
+    if min_occurence_counter > 0: # perform minimum occcurence check
+        sources_counter = Counter(mapped_sources) # Counter for how many times a Source occurs
+        count_keys = list(sources_counter.keys()) # create a list from the counter key/source id
+        for key in count_keys: # loop through each counter key/source id
+            if sources_counter[key] < min_occurence_counter: # if counter key/source id < min_occurence counter
+                # remove this key as it represents a Source that occurs less than requested
+                del sources_counter[key]
+        # end of minimum occurence checks,
+        # so, generate the 'mapped' source list from the results of this check
+        mapped_sources = sources_counter.elements()
+
+    # get distinct (non-duplicate) 'mapped' source_list
+    mapped_sources = set(mapped_sources)
+
+    distinct_source_list = [] # holds the list of distinct source objects
+    # iterate through 'mapped_source'
+    for mapped_source in mapped_sources:
+        # iterate through 'source_list'  parameter
+        for source in source_list:
+            # the source has the same id or title as mapped_source
+            if source.get('source_id', source['source_title']) == mapped_source:
+                # add this source to the list of distinct source objects
+                distinct_source_list.append(source)
                 break # leave the inner loop
     
-    return distinct_collection_list # return the distinct collection
+    return distinct_source_list # return the distinct source

--- a/edscrapers/transformers/sources/transform.py
+++ b/edscrapers/transformers/sources/transform.py
@@ -1,11 +1,10 @@
 """ module transforms the raw dataset files (i.e. the results/output from scraping)
-into a different json data structure referred to as Collections.
+into a different json data structure referred to as Sources.
 Each scraping output directory will have its own
-collections file upon completion of the transformation. Files are titled
-'{name}.collections.json' .
-All transformation output is written into 'collections' subdirectory of the
-'transformers' directory on 'ED_OUTPUT_PATH'
-"""
+sources file upon completion of the transformation. Files are titled
+'{name}.sources.json' .
+All transformation output is written into 'sources' subdirectory of the
+'transformers' directory on 'ED_OUTPUT_PATH' """
 
 import os
 import json

--- a/edscrapers/transformers/sources/transform.py
+++ b/edscrapers/transformers/sources/transform.py
@@ -53,7 +53,7 @@ def transform(name=None, input_file=None):
         sources_list.append(source)
 
     # get a list of non-duplicate Sources
-    sources_list = get_distinct_sources_from(sources_list, min_occurence_counter=1)
+    sources_list = get_distinct_sources_from(sources_list, min_occurence_counter=2)
     # get the path were the gotten Sources will be saved to on local disk
     file_output_path = f'{CURRENT_TRANSFORMER_OUTPUT_DIR}/{(name or "all")}.sources.json'
     # write to file the Sources gotten from 'name' scraped output
@@ -100,7 +100,7 @@ def get_distinct_sources_from(source_list,
     Sources from
 
     - min_occurence_counter: the operations used to identify a distinct Source can 
-    be instructed on how to identify a Collection for consideration. The
+    be instructed on how to identify a Source for consideration. The
     'min_occurence_counter' instructs the algorithm to
     ignore/remove a Source from the list of distinct Sources if it does not
     occur/appear within the provided 'sources_list' at least that number of times.

--- a/edscrapers/transformers/sources/transform.py
+++ b/edscrapers/transformers/sources/transform.py
@@ -34,7 +34,7 @@ def transform(name=None, input_file=None):
             with open(input_file, 'r') as fp:
                 file_list = [line.rstrip() for line in fp]
         except:
-            logger.warn(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
+            logger.warning(f'Cannot read from list of output files at {input_file}, falling back to all collected data!')
             file_list = h.traverse_output(name)
     
     sources_list = [] # holds the list of sources acquired from 'name' scraper directory


### PR DESCRIPTION
### TASK TACKLED:
- minor bugfixes and speed improvements to the scraping and transform process
- implemented sources and collections for scraped output
- generating sources and/or collections from scraped out is completely decoupled/optional
- to generate scraping datajson with sources and/or collections, do:
    1. run `eds scrape ocr`
    2. run `eds transform --name ocr sources`
    3. run `eds transform --name ocr collections`
    4. run `eds transform --name ocr datajson`
    5. your final output is in the datajson transformer output directory (as always)