### PR TITLE
Ope collections sources

### DIFF
--- a/edscrapers/scrapers/base/helpers.py
+++ b/edscrapers/scrapers/base/helpers.py
@@ -192,6 +192,7 @@ def extract_dataset_collection_from_url(collection_url,
                             find(name='title').string).strip()
     else:
       collection['collection_title'] = '[no title]'
+
     collection['collection_id'] =\
         f'{hashlib.md5(collection["collection_url"].encode("utf-8")).hexdigest()}-{hashlib.md5(namespace.encode("utf-8")).hexdigest()}'
 
@@ -243,8 +244,13 @@ def extract_dataset_source_from_url(source_url, namespace):
     
     source = Source()
     source['source_url'] = source_url
-    source['source_title'] = str(soup_parser.head.\
+    # get the Source title
+    if soup_parser.head.find(name='title'):
+        source['source_title'] = str(soup_parser.head.\
                             find(name='title').string).strip()
+    else:
+        source['source_title'] = '[no title]'
+    
     source['source_id'] =\
         f'{hashlib.md5(source["source_url"].encode("utf-8")).hexdigest()}-{hashlib.md5(namespace.encode("utf-8")).hexdigest()}'
 

--- a/edscrapers/scrapers/base/helpers.py
+++ b/edscrapers/scrapers/base/helpers.py
@@ -4,8 +4,11 @@ import logging
 import datetime
 import hashlib
 import urllib.parse
+import itertools
 import requests
 import bs4
+import ratelimit
+import backoff
 
 from urllib.parse import urlparse
 from urllib.parse import urljoin
@@ -17,6 +20,15 @@ import importlib
 
 logger = logging.getLogger(__name__)
 
+# some of the sites scraped have rate limits so we need to throttle.
+# a simple throttling implementation is employed for some api calls (that are affected by rate limits) within this module because
+# such calls occur outside of scrapy's control and need to be catered for.
+NUMBER_OF_CALLS_PER_LIMIT_WINDOWS = 3 # number of api calls allowed per rate limit period/window
+RATE_LIMIT_WINDOW = 3 # time period (in seconds) within which 'NUMBER_OF_CALLS_PER_LIMIT_WINDOWS' are allowed
+NUMBER_OF_RETRIES_AFTER_LIMIT = 10 # total number of times to retry a rate-limited api call
+# total number of time (in seconds) which the exponential backoff algorithm (for rate-limited api call) will wait before final failure
+TOTAL_BACKOFF_TIME = sum(itertools.accumulate(itertools.repeat(RATE_LIMIT_WINDOW, 
+                                    NUMBER_OF_RETRIES_AFTER_LIMIT+1)))
 
 def get_data_extensions():
     return {
@@ -81,6 +93,12 @@ def get_meta_value(soup, meta_name):
             return None
     return meta_tag['content']
 
+
+@backoff.on_exception(backoff.expo, Exception,
+                      max_time=TOTAL_BACKOFF_TIME,
+                      max_tries=NUMBER_OF_RETRIES_AFTER_LIMIT) # exponential backoff
+@ratelimit.limits(calls=NUMBER_OF_CALLS_PER_LIMIT_WINDOWS,
+                  period=RATE_LIMIT_WINDOW) # apply rate-limit throttling
 def get_resource_headers(source_url, url):
     headers = dict()
     if urlparse(url).scheme:
@@ -137,6 +155,11 @@ def retrieve_crawlers_allowed_domains(except_crawlers=[]) -> list:
     return list(allowed_domains) # return allowed_domains
 
 
+@backoff.on_exception(backoff.expo, Exception,
+                      max_time=TOTAL_BACKOFF_TIME,
+                      max_tries=NUMBER_OF_RETRIES_AFTER_LIMIT) # exponential backoff
+@ratelimit.limits(calls=NUMBER_OF_CALLS_PER_LIMIT_WINDOWS,
+                  period=RATE_LIMIT_WINDOW) # apply rate-limit throttling
 def extract_dataset_collection_from_url(collection_url,
                                         namespace, source_url=None):
     """ function is used to generate/extract a dataset 'Collection' from
@@ -171,6 +194,13 @@ def extract_dataset_collection_from_url(collection_url,
 
     # cleanup the collection_url i.e. remove all query parameters
     collection_url = url_query_param_cleanup(collection_url, include_query_param=[])
+    # compare collection_url and source_url
+    if source_url and urlparse(source_url).scheme: # first make sure source_url is valid
+        # now the comparison
+        if collection_url == url_query_param_cleanup(source_url, include_query_param=[]):
+            # collection_url and source_url are the same, so this is not a valid collection
+            return None
+
 
     # make a request for html page contained in the provided url
     res = requests.get(collection_url, verify=False)
@@ -204,6 +234,11 @@ def extract_dataset_collection_from_url(collection_url,
     return collection
 
 
+@backoff.on_exception(backoff.expo, Exception,
+                      max_time=TOTAL_BACKOFF_TIME,
+                      max_tries=NUMBER_OF_RETRIES_AFTER_LIMIT) # exponential backoff
+@ratelimit.limits(calls=NUMBER_OF_CALLS_PER_LIMIT_WINDOWS,
+                  period=RATE_LIMIT_WINDOW) # apply rate-limit throttling
 def extract_dataset_source_from_url(source_url, namespace):
     """ function is used to generate/extract a dataset 'Source' from
     the provided source_url.

--- a/edscrapers/scrapers/ocr/crawler.py
+++ b/edscrapers/scrapers/ocr/crawler.py
@@ -23,8 +23,8 @@ class Crawler(CrawlSpider):
             #'https://ocrdata.ed.gov/StateNationalEstimations'
             'https://ocrdata.ed.gov/Home',
             'https://ocrdata.ed.gov/DistrictSchoolSearch',
-            'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
-            'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
+            #'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
+            #'https://ocrdata.ed.gov/StateNationalEstimations/Estimations_2011_12#',
             'https://ocrdata.ed.gov/DownloadDataFile',
             'https://ocrdata.ed.gov/StateNationalEstimations',
             'https://ocrdata.ed.gov/SpecialReports',

--- a/edscrapers/scrapers/ocr/parsers/ocr_state_national_estimates_parser1.py
+++ b/edscrapers/scrapers/ocr/parsers/ocr_state_national_estimates_parser1.py
@@ -26,8 +26,8 @@ def parse(res) -> dict:
         collection = h.extract_dataset_collection_from_url(collection_url=res.url,
                                         namespace="all",
                                         source_url=\
-                                        str(res.request.headers[str(b'Referer',
-                                                                    encoding='utf-8')], 
+                                        str(res.request.headers.get(str(b'Referer',
+                                                                    encoding='utf-8'), b''), 
                                             encoding='utf-8'))
 
     for container in dataset_containers:

--- a/edscrapers/scrapers/ocr/parsers/ocr_state_national_estimates_parser2.py
+++ b/edscrapers/scrapers/ocr/parsers/ocr_state_national_estimates_parser2.py
@@ -29,8 +29,8 @@ def parse(res) -> dict:
         collection = h.extract_dataset_collection_from_url(collection_url=res.url,
                                         namespace="all",
                                         source_url=\
-                                        str(res.request.headers[str(b'Referer',
-                                                                    encoding='utf-8')], 
+                                        str(res.request.headers.get(str(b'Referer',
+                                                                    encoding='utf-8'), b''), 
                                             encoding='utf-8'))
 
     for container in dataset_containers:

--- a/edscrapers/scrapers/ope/parsers/ope_parser1.py
+++ b/edscrapers/scrapers/ope/parsers/ope_parser1.py
@@ -20,6 +20,17 @@ def parse(res) -> dict:
     dataset_containers = soup_parser.body.find_all(name='div',
                                                    id='maincontent',
                                                    recursive=True)
+
+    # check if this page is a collection (i.e. collection of datasets)
+    if len(dataset_containers) > 0: # this is a collection
+        # create the collection (with a source)
+        collection = h.extract_dataset_collection_from_url(collection_url=res.url,
+                                        namespace="all",
+                                        source_url=\
+                                        str(res.request.headers.get(str(b'Referer',
+                                                                    encoding='utf-8'), b''), 
+                                            encoding='utf-8'))
+
     for container in dataset_containers:
         # create dataset model dict
         dataset = Dataset()
@@ -61,6 +72,10 @@ def parse(res) -> dict:
         dataset['contact_person_name'] = ""
 
         dataset['contact_person_email'] = ""
+
+        # specify the collection which the dataset belongs to
+        if collection: # if collection exist
+            dataset['collection'] = collection
 
         dataset['resources'] = list()
 

--- a/edscrapers/scrapers/ope/parsers/ope_parser2.py
+++ b/edscrapers/scrapers/ope/parsers/ope_parser2.py
@@ -19,6 +19,16 @@ def parse(res) -> dict:
 
     dataset_containers = soup_parser.body.find_all(class_='contentText',
                                                    recursive=True)
+
+    # check if this page is a collection (i.e. collection of datasets)
+    if len(dataset_containers) > 0: # this is a collection
+       # create the collection (with a source)
+        collection = h.extract_dataset_collection_from_url(collection_url=res.url,
+                                        namespace="all",
+                                        source_url=\
+                                        str(res.request.headers.get(str(b'Referer',
+                                                                    encoding='utf-8'), b''), 
+                                            encoding='utf-8'))
     for container in dataset_containers:
         # create dataset model dict
         dataset = Dataset()
@@ -60,6 +70,10 @@ def parse(res) -> dict:
         dataset['contact_person_name'] = ""
 
         dataset['contact_person_email'] = ""
+
+        # specify the collection which the dataset belongs to
+        if collection: # if collection exist
+            dataset['collection'] = collection
 
         dataset['resources'] = list()
 

--- a/edscrapers/transformers/datajson/models.py
+++ b/edscrapers/transformers/datajson/models.py
@@ -448,12 +448,14 @@ class Resource():
     mediaType = str()
     accessURL = str()
     downloadURL = str()
+    headerMetadata = dict()
 
     def __init__(self):    
         self.resource_type = "dcat:Distribution"
         self.description = "n/a"
         self.resource_format = "txt"
         self.mediaType = h.get_media_type(self.resource_format)
+        self.headerMetadata = dict()
 
     def to_dict(self):
 
@@ -479,5 +481,8 @@ class Resource():
 
         if self.mediaType:
             resource_dict["mediaType"] = self.mediaType
+        
+        if len(list(self.headerMetadata.keys())) > 0:
+            resource_dict["headerMetadata"] = self.headerMetadata
 
         return resource_dict

--- a/edscrapers/transformers/datajson/transform.py
+++ b/edscrapers/transformers/datajson/transform.py
@@ -70,9 +70,9 @@ def transform(name, input_file=None):
         logger.warning(f'"sources transformer" output file ({(name or "all")}.sources.json) not found. This datajson output will have no "source" field')
     
     # add the list of Source objects to the catalog
-    catalog.sources = catalog_sources
+    catalog.sources = catalog_sources or []
     # update the number fo transformed Sources
-    sources_number = len(catalog_sources)
+    sources_number = len(catalog_sources or [])
     
     # get the list of Collections for this catalog
     catalog_collections = list()
@@ -85,9 +85,9 @@ def transform(name, input_file=None):
         logger.warning(f'"sources transformer" output file ({(name or "all")}.collections.json) not found. This datajson output will have no "collection" field')
     
     # add the list of Collection objects to the catalog
-    catalog.collections = catalog_collections
+    catalog.collections = catalog_collections or []
     # update the number fo transformed Collections
-    collections_number = len(catalog_collections)
+    collections_number = len(catalog_collections or [])
 
     # validate the catalog object
     if not catalog.validate_catalog(pls_fix=True):
@@ -240,6 +240,9 @@ def _transform_scraped_resource(target_dept, resource):
         if extension:
             distribution.resource_format = extension
             distribution.mediaType = h.get_media_type(extension)
+    
+    if resource.get('headers'):
+        distribution.headerMetadata = resource.get('headers')
 
     return distribution
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -i https://pypi.org/simple
 attrs==19.3.0
 automat==20.2.0
+backoff==1.10.0
 beautifulsoup4==4.8.2
 boto3==1.12.31
 botocore==1.15.31
@@ -52,6 +53,7 @@ python-slugify==4.0.0
 pytz==2019.3
 pyyaml==5.3
 queuelib==1.5.0
+ratelimit==2.2.1
 requests==2.23.0
 retrying==1.3.3
 s3transfer==0.3.3


### PR DESCRIPTION
TASKS TACKLED
- fixed metadata request headers retrieval
- resource headers now available in datajson transformer output
- fixed backtracking issue caused by 'false' referer head AKA bug where collections and sources are the same
- implemented simple throttling for requests of resources which are outside of scrapy's control. this solves rate limit errors
- other performance and resilience improvements