### PR TITLE
graphs-without-datasets: fixes the problem when running deduplication on graphs without dataset vertices

### DIFF
--- a/edscrapers/scrapers/base/graph.py
+++ b/edscrapers/scrapers/base/graph.py
@@ -86,7 +86,11 @@ class GraphWrapper():
 
         with cls.graph.graph_lock:
             # get the VertexSequence for the pages we want to create legends for
-            vertex_seq = cls.graph.vs.select(is_dataset_eq=None) # get vertices NOT flagged as dataset
+            try:
+                vertex_seq = cls.graph.vs.select(is_dataset_eq=None) # get vertices NOT flagged as dataset
+            except:
+                vertex_seq = cls.graph.vs # since no dataset vertex, select all the vertices
+                
             # create a dataframe that will contain the info to be written to csv
             df = pd.DataFrame(columns=['Page Label', 'Page Title', 'Page URL'])
             df['Page Label'] = vertex_seq['label']

--- a/edscrapers/transformers/deduplicate/transform.py
+++ b/edscrapers/transformers/deduplicate/transform.py
@@ -59,7 +59,10 @@ def find_duplicate_dataset_vertices(graph,
 
     with graph.graph_lock: # activate lock on graph
         # find the dataset vertices to be dropped
-        dropped_dataset_ver_seq = graph.vs.select(is_dataset_eq=True, name_notin=kept_dataset_file_paths)
+        try:
+            dropped_dataset_ver_seq = graph.vs.select(is_dataset_eq=True, name_notin=kept_dataset_file_paths)
+        except:
+            dropped_dataset_ver_seq = [] # since there are no dataset vertices, produce an empty list
     
     return dropped_dataset_ver_seq
 


### PR DESCRIPTION
**Bug fix**
fixes the problem when running deduplication on graphs without datasets vertices